### PR TITLE
fixed: support one more breaking change from go module bs

### DIFF
--- a/cmd_get.go
+++ b/cmd_get.go
@@ -59,7 +59,7 @@ to the underlying go get command.
 			}()
 		}
 
-		c := exec.Command("go", append([]string{"get"}, args...)...)
+		c := exec.Command("go", append([]string{"get", "-d"}, args...)...)
 		c.Stdin = os.Stdin
 		c.Stderr = os.Stderr
 		c.Stdout = os.Stdout

--- a/internal/remod/update.go
+++ b/internal/remod/update.go
@@ -28,7 +28,7 @@ func Update(modules []string, version string) error {
 
 		mod = fmt.Sprintf("%s@%s", mod, version)
 
-		cmd := exec.Command("go", "get", mod)
+		cmd := exec.Command("go", "get", "-d", mod)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
Go 1.17 requires to use `go get -d` to support getting package with a main. Thank you Go team for once again breaking people's tools